### PR TITLE
don't use `bl` which depends on `readable-stream`.

### DIFF
--- a/bl-state.js
+++ b/bl-state.js
@@ -1,39 +1,4 @@
-
-var BufferList = require('bl')
-
 module.exports = function () {
-
-  var bl = new BufferList()
-
-  function get (n) {
-    var len = n == null ? bl.length : n
-    var data = bl.slice(0, len)
-    bl.consume(n)
-    return data
-  }
-
-  return {
-    data: bl,
-    add: function (data) {
-      bl.append(data)
-      return this
-    },
-    has: function (n) {
-      if(n == null) return bl.length > 0
-      return bl.length >= n
-
-    },
-    get: function (n) {
-      if(n == null) return get()
-      if(!this.has(n))
-        throw new Error(
-          'current length is:'+bl.length
-          + ', could not get:'+n + ' bytes'
-        )
-      return get(n)
-    }
-  }
-
   var soFar = new Buffer(0)
 
   return {
@@ -61,5 +26,4 @@ module.exports = function () {
       return next
     }
   }
-
 }

--- a/package.json
+++ b/package.json
@@ -14,9 +14,7 @@
     "pull-stream": "~2.26.0",
     "tape": "~4.0.0"
   },
-  "dependencies": {
-    "bl": "^1.1.2"
-  },
+  "dependencies": {},
   "scripts": {
     "prepublish": "npm ls &&  npm test",
     "test": "set -e; for t in test/*.js; do node $t; done"


### PR DESCRIPTION
this change reduces browser bundle sizes, which is important as this module is used in `packet-stream-codec` used in `muxrpc`.

@dominictarr: it seems you implemented this with _and without_ `bl`, so i just removed the `bl` version, and things seem to work just fine. even the bench seems more or less the same. wonder if you have any context i'm missing or if i should implement this differently or ... thanks!
