### PR TITLE
return an error when there are insufficient bytes

### DIFF
--- a/state.js
+++ b/state.js
@@ -12,11 +12,15 @@ module.exports = function () {
 
   return {
     length: length,
+    total: 0,
     data: this,
+    wants: 0,
+    read: 0,
     add: function (data) {
       if(!Buffer.isBuffer(data))
         throw new Error('data must be a buffer, was: ' + JSON.stringify(data))
       this.length = length = length + data.length
+      this.total += data.length
       buffers.push(data)
       return this
     },
@@ -24,7 +28,7 @@ module.exports = function () {
       if(null == n) return length > 0
       return length >= n
     },
-    get: function (n) {
+    _get: function (n) {
       var _length
       if(n == null || n === length) {
         length = 0
@@ -62,12 +66,12 @@ module.exports = function () {
       }
       else
         throw new Error('could not get ' + n + ' bytes')
+    },
+    get: function(n) {
+      var b = this._get(n)
+      this.read += b.length
+      return b
     }
   }
 
 }
-
-
-
-
-

--- a/test/read.js
+++ b/test/read.js
@@ -181,7 +181,7 @@ tape('if streaming, the stream should abort', function (t) {
 
 tape('abort stream once in streaming mode', function (t) {
 
-  var reader = Reader(), err = new Error('intended')
+  var reader = Reader()
 
   pull(Hang(), reader)
 
@@ -232,7 +232,6 @@ tape('timeout does not apply to the rest of the stream', function (t) {
   pull(
     reader.read(),
     pull.collect(function (err, ary) {
-      console.log(err)
       t.notOk(err)
       t.equal(Buffer.concat(ary).toString(), 'hello world')
       t.end()
@@ -241,6 +240,37 @@ tape('timeout does not apply to the rest of the stream', function (t) {
 })
 
 
+tape('overreading results in an error', function (t) {
+  var corruptedBytes = crypto.randomBytes(10)
+
+  pull(
+    pull.values([corruptedBytes]),
+    reader = Reader(20e3)
+  )
+
+  reader.read(11, function(_err) {
+    t.ok(_err)
+    t.equal(_err.message, 'attempted to read 11 of 10 bytes')
+    t.end()
+  })
+})
 
 
+tape('overreading with multiple reads results in an error', function (t) {
+  var corruptedBytes = crypto.randomBytes(10)
+
+  pull(
+    pull.values([corruptedBytes]),
+    reader = Reader()
+  )
+
+  reader.read(1, function(err) {
+    t.notOk(err)
+    reader.read(100, function(_err) {
+      t.ok(_err)
+      t.equal(_err.message, 'attempted to read 101 of 10 bytes')
+      t.end()
+    })
+  })
+})
 


### PR DESCRIPTION
This aims to resolve #5. This could probably be cleaner and I'm not positive I'm missing certain scenarios but I have tested this in several integrations in addition to the tests added for this. I'm happy to make updates and/or add some additional scenarios to the tests.

This updates the state to additionally keep track of how much data was requested (`wants`), how much data has been `read` and the `total` number of bytes that have gone through the states buffers. The idea, as mentioned in the comments for `didOverread` is to check if we're requesting bytes in excess of what is available, without breaking successive reads.

I've verified this integrated with:
* pull-length-prefixed test suites, including the added (unskipped) test at https://github.com/dignifiedquire/pull-length-prefixed/pull/8
* In [ipfs/js-ipfs](https://github.com/ipfs/js-ipfs) to interact with both js and go network streams
* the [libp2p/js-libp2p](https://github.com/libp2p/js-libp2p) test suite

