### PR TITLE
simpler version #6

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,8 @@ module.exports = function (timeout) {
         var next = queue.shift()
         next.cb(null, state.get(next.length))
       }
+      else if(ended == true && queue[0].length && state.length < queue[0].length)
+        queue.shift().cb(new Error('stream ended with:'+state.length+' but wanted:'+queue.length))
       else if(ended)
         queue.shift().cb(ended)
       else

--- a/test/read.js
+++ b/test/read.js
@@ -181,7 +181,7 @@ tape('if streaming, the stream should abort', function (t) {
 
 tape('abort stream once in streaming mode', function (t) {
 
-  var reader = Reader(), err = new Error('intended')
+  var reader = Reader()
 
   pull(Hang(), reader)
 
@@ -232,7 +232,6 @@ tape('timeout does not apply to the rest of the stream', function (t) {
   pull(
     reader.read(),
     pull.collect(function (err, ary) {
-      console.log(err)
       t.notOk(err)
       t.equal(Buffer.concat(ary).toString(), 'hello world')
       t.end()
@@ -241,6 +240,37 @@ tape('timeout does not apply to the rest of the stream', function (t) {
 })
 
 
+tape('overreading results in an error', function (t) {
+  var corruptedBytes = crypto.randomBytes(10)
+
+  pull(
+    pull.values([corruptedBytes]),
+    reader = Reader(20e3)
+  )
+
+  reader.read(11, function(_err) {
+    t.ok(_err)
+    t.end()
+  })
+})
+
+
+tape('overreading with multiple reads results in an error', function (t) {
+  var corruptedBytes = crypto.randomBytes(10)
+
+  pull(
+    pull.values([corruptedBytes]),
+    reader = Reader()
+  )
+
+  reader.read(1, function(err) {
+    t.notOk(err)
+    reader.read(100, function(_err) {
+      t.ok(_err)
+      t.end()
+    })
+  })
+})
 
 
 


### PR DESCRIPTION
@jacobheun I realized much simpler fix was possible.

maxDelay should not be changed, it's out of the scope because it's intended to be generic (possibly published as module, if needed again, etc)

State should also not be changed, because it's intended to be the same API is bufferlist.

however, we don't actually need to store any more state, because the read queue already remembers the length requested, and the state remembers the length read. This doesn't give the total length requested, though. timeout already has an error...

I also removed the test's dependence on the error message. I'd advise against treating error messages as API - they are for humans, if you need machine readable errors, add properties to them. (otherwise, you can't make more informative error messages without breaking things)